### PR TITLE
Fixing shift-register code

### DIFF
--- a/arduino_code/openKnitting_handMadepcb_v0_1/openKnitting_handMadepcb_v0_1.pde
+++ b/arduino_code/openKnitting_handMadepcb_v0_1/openKnitting_handMadepcb_v0_1.pde
@@ -202,7 +202,6 @@ public:
     else{ 
       directionEncoders += "OFF"; 
     }
-    //directionEncoders += "-";
     last8segmentEncoder = _8segmentEncoder;
     _8segmentEncoder = "";
     if(digitalRead(encoder0PinC)== HIGH){ 
@@ -250,13 +249,13 @@ public:
       }
       else{
         headDirection = headDirection*-1;
-        Serial.println("change direction"+String(headDirection));
+        //Serial.println("change direction"+String(headDirection));
       }
       headDirectionAverage = 0;
       segmentPosition +=headDirection;
       encoder0Pos = segmentPosition*8;
       /*
-                            Serial.print(",s,");
+       Serial.print(",s,");
        Serial.print(headDirection);
        Serial.print(",");
        Serial.print(segmentPosition);


### PR DESCRIPTION
I'm debugging the shift-register code in the arduino.

I had these lines in there:
    `//return the latch pin high to signal chip that it`
    `//no longer needs to listen for information`

but the command to actually do those things wasn't there. Maybe it got lost on some merge... but I doubt it... anyway... 

I put this line back in and it works:
    `digitalWrite(latchPin, 1);`

It seems like there's still an issue. I'm suspicious of these lines: 
      `//Sets the pin to HIGH or LOW depending on pinState`
      `digitalWrite(myDataPin, pinState);`
      `//register shifts bits on upstroke of clock pin`
      `digitalWrite(myClockPin, 1);`
      `//zero the data pin after shift to prevent bleed through`
      `digitalWrite(myDataPin, 0);`

It seems like there should be a clock = 0 at some point in there... I'll look!
